### PR TITLE
feat: add cleanupAttrs and convertColors plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +192,18 @@ dependencies = [
  "jiff",
  "log",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -346,10 +424,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "svgo-rs"
 version = "0.1.0"
 dependencies = [
  "bumpalo",
+ "derive_builder",
  "env_logger",
  "lazy_static",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +206,17 @@ dependencies = [
  "env_filter",
  "jiff",
  "log",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -436,6 +462,7 @@ dependencies = [
  "bumpalo",
  "derive_builder",
  "env_logger",
+ "fancy-regex",
  "lazy_static",
  "log",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,15 @@ version    = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-bumpalo     = { version = "3.17.0", features = ["collections"] }
-env_logger  = "0.11.8"
-lazy_static = "1.4.0"
-log         = "0.4.27"
-napi        = { version = "2.16.17", features = ["napi6"] }
-napi-derive = "2.16.13"
-quick-xml   = "0.37.3"
-regex       = "1.11.1"
+bumpalo        = { version = "3.17.0", features = ["collections"] }
+derive_builder = "0.20.2"
+env_logger     = "0.11.8"
+lazy_static    = "1.4.0"
+log            = "0.4.27"
+napi           = { version = "2.16.17", features = ["napi6"] }
+napi-derive    = "2.16.13"
+quick-xml      = "0.37.3"
+regex          = "1.11.1"
 
 [build-dependencies]
 napi-build = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib"]
 bumpalo        = { version = "3.17.0", features = ["collections"] }
 derive_builder = "0.20.2"
 env_logger     = "0.11.8"
+fancy-regex    = "0.14.0"
 lazy_static    = "1.4.0"
 log            = "0.4.27"
 napi           = { version = "2.16.17", features = ["napi6"] }

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -4,28 +4,15 @@ import { optimize } from '../index'
 test('sync function from native code', () => {
   const inputXml = `
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="100px" height="100px" viewBox="0 0 100 100"
-     xmlns="http://www.w3.org/2000/svg"
-     xmlns:xlink="http://www.w3.org/1999/xlink"
-     xmlns:myeditor="http://www.myeditor.com/ns"
-     version="1.1">
-    <myeditor:metadata>
-        <myeditor:source>AwesomeIcon Design</myeditor:source>
-        <myeditor:version>1.2</myeditor:version>
-        <myeditor:exporter>MyEditor Pro Exporter v3.0</myeditor:exporter>
-    </myeditor:metadata>
-    <title>My Awesome Icon</title>
-    <desc>A blue circle with a red star inside.</desc>
-    <g id="BackgroundLayer" myeditor:layerName="Background">
-        <circle cx="50" cy="50" r="45" fill="blue" id="blue_circle_bg" myeditor:objectID="obj123"/>
-    </g>
-    <g id="ForegroundLayer" myeditor:layerName="Foreground" myeditor:isDecorative="false">
-        <polygon points="50,15 61,35 85,35 67,50 73,70 50,60 27,70 33,50 15,35 39,35"
-                 fill="red"
-                 id="red_star_shape"
-                 myeditor:objectID="obj456"
-                 myeditor:customAttribute="important_shape"/>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox=" 0 0  150 100 " width="150">
+  <!-- Created with love! -->
+  <defs>
+    <ellipse cx="50" cy="50.0" rx="50.00" ry="auto" fill="black" id="circle"/>
+  </defs>
+  <g>
+    <use href="#circle" transform="skewX(16)"/>
+    <rect id="useless" width="0" height="0" fill="#ff0000"/>
+  </g>
 </svg>
 `
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "bench": "node --import @swc-node/register/esm-register benchmark/bench.ts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "format": "format:rs && format:toml",
+    "format": "yarn format:rs && yarn format:toml",
     "format:toml": "taplo format",
     "format:rs": "cargo fmt",
     "lint": "biome lint --write",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use bumpalo::Bump;
 use napi_derive::napi;
 use optimizer::SvgOptimizer;
 use parser::parse_svg;
+use plugins::cleanup_attrs::{CleanupAttrs, CleanupAttrsConfigBuilder};
 use plugins::move_elems_attrs_to_group::{
   MoveElemsAttrsToGroupPlugin, MoveElemsAttrsToGroupPluginConfig,
 };
@@ -57,6 +58,10 @@ pub fn optimize(input_xml: String) -> String {
       RemoveEditorsNSDataConfig {
         additional_namespace: None,
       },
+      &arena,
+    )),
+    Box::new(CleanupAttrs::new(
+      CleanupAttrsConfigBuilder::default().build().unwrap(),
       &arena,
     )),
   ]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use napi_derive::napi;
 use optimizer::SvgOptimizer;
 use parser::parse_svg;
 use plugins::cleanup_attrs::{CleanupAttrs, CleanupAttrsConfigBuilder};
+use plugins::convert_colors::{ConvertColorsPlugin, ConvertColorsPluginConfigBuilder};
 use plugins::move_elems_attrs_to_group::{
   MoveElemsAttrsToGroupPlugin, MoveElemsAttrsToGroupPluginConfig,
 };
@@ -62,6 +63,10 @@ pub fn optimize(input_xml: String) -> String {
     )),
     Box::new(CleanupAttrs::new(
       CleanupAttrsConfigBuilder::default().build().unwrap(),
+      &arena,
+    )),
+    Box::new(ConvertColorsPlugin::new(
+      ConvertColorsPluginConfigBuilder::default().build().unwrap(),
       &arena,
     )),
   ]);

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -202,7 +202,7 @@ impl<'a> SvgOptimizer<'a> {
       }
       XMLAstChild::Text(t) => {
         // 文本节点
-        buf.push_str(&t.value);
+        buf.push_str(t.value);
       }
       XMLAstChild::Comment(c) => {
         // 注释

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -20,7 +20,7 @@ pub trait Plugin<'a> {
   fn element_enter(&mut self, _el: &mut XMLAstElement<'a>) -> VisitAction {
     VisitAction::Keep
   }
-  fn element_exit(&self, _el: &mut XMLAstElement<'a>) {}
+  fn element_exit(&mut self, _el: &mut XMLAstElement<'a>) {}
 
   fn text_enter(&self, _el: &mut XMLAstText<'a>) -> VisitAction {
     VisitAction::Keep
@@ -121,7 +121,7 @@ impl<'a> SvgOptimizer<'a> {
         XMLAstChild::Element(el) => {
           // Traverse children before calling exit hooks for the parent
           self.traverse_children(&mut el.children);
-          for plugin in &self.plugins {
+          for plugin in &mut self.plugins {
             plugin.element_exit(el);
           }
         }

--- a/src/plugins/cleanup_attrs.rs
+++ b/src/plugins/cleanup_attrs.rs
@@ -56,7 +56,7 @@ impl<'a> Plugin<'a> for CleanupAttrs<'a> {
     // where the second element (value) can be reassigned to a new &'a str
     // allocated in the arena.
     for (_attr_name, attr_value_ref) in el.attributes.iter_mut() {
-      let original_value: &'a str = *attr_value_ref;
+      let original_value: &'a str = attr_value_ref;
       let mut current_value: Cow<'a, str> = Cow::Borrowed(original_value);
 
       let mut modified = false;

--- a/src/plugins/cleanup_attrs.rs
+++ b/src/plugins/cleanup_attrs.rs
@@ -1,0 +1,113 @@
+use bumpalo::collections::String as BumpString; // For allocating new strings into the arena
+use bumpalo::Bump;
+use derive_builder::Builder;
+use regex::Regex;
+use std::borrow::Cow; // Useful for avoiding allocations if string doesn't change
+
+use crate::optimizer::{Plugin, VisitAction};
+use crate::parser::XMLAstElement; // Assuming this is the correct path to your AST element
+
+/// Configuration for the cleanupAttrs plugin.
+#[derive(Debug, Builder, Default)]
+pub struct CleanupAttrsConfig {
+  /// Process newlines. (default: true)
+  /// - Replaces newlines surrounded by non-whitespace with a single space.
+  /// - Removes other newlines.
+  #[builder(default = "true")]
+  pub newlines: bool,
+  /// Trim leading and trailing whitespace from attribute values. (default: true)
+  #[builder(default = "true")]
+  pub trim: bool,
+  /// Collapse multiple whitespace characters into a single space. (default: true)
+  #[builder(default = "true")]
+  pub spaces: bool,
+}
+
+pub struct CleanupAttrs<'a> {
+  arena: &'a Bump,
+  config: CleanupAttrsConfig,
+  // Compiled regexes for efficiency
+  reg_newlines_need_space: Regex,
+  reg_newlines: Regex,
+  reg_spaces: Regex,
+}
+
+impl<'a> CleanupAttrs<'a> {
+  pub fn new(config: CleanupAttrsConfig, arena: &'a Bump) -> Self {
+    // It's generally good practice to compile regexes once.
+    // unwrap() is used here for simplicity; in production, consider error handling.
+    let reg_newlines_need_space = Regex::new(r"(\S)\r?\n(\S)").unwrap();
+    let reg_newlines = Regex::new(r"\r?\n").unwrap();
+    let reg_spaces = Regex::new(r"\s{2,}").unwrap();
+
+    Self {
+      arena,
+      config,
+      reg_newlines_need_space,
+      reg_newlines,
+      reg_spaces,
+    }
+  }
+}
+
+impl<'a> Plugin<'a> for CleanupAttrs<'a> {
+  fn element_enter(&mut self, el: &mut XMLAstElement<'a>) -> VisitAction {
+    // Assuming el.attributes is Vec<(&'a str, &'a str)> or similar
+    // where the second element (value) can be reassigned to a new &'a str
+    // allocated in the arena.
+    for (_attr_name, attr_value_ref) in el.attributes.iter_mut() {
+      let original_value: &'a str = *attr_value_ref;
+      let mut current_value: Cow<'a, str> = Cow::Borrowed(original_value);
+
+      let mut modified = false;
+
+      if self.config.newlines {
+        // 1. Newlines that need a space (e.g., text\ntext -> text text)
+        let after_needed_space = self
+          .reg_newlines_need_space
+          .replace_all(&current_value, "$1 $2");
+        if after_needed_space.as_ref() != current_value.as_ref() {
+          current_value = Cow::Owned(after_needed_space.into_owned());
+          modified = true;
+        }
+
+        // 2. Other newlines (remove them)
+        let after_simple_newlines = self.reg_newlines.replace_all(&current_value, "");
+        if after_simple_newlines.as_ref() != current_value.as_ref() {
+          current_value = Cow::Owned(after_simple_newlines.into_owned());
+          modified = true;
+        }
+      }
+
+      if self.config.trim {
+        let trimmed_value = current_value.trim();
+        if trimmed_value != current_value.as_ref() {
+          current_value = Cow::Owned(trimmed_value.to_string());
+          modified = true;
+        }
+      }
+
+      if self.config.spaces {
+        // Collapse multiple spaces into one
+        let after_spaces = self.reg_spaces.replace_all(&current_value, " ");
+        if after_spaces.as_ref() != current_value.as_ref() {
+          current_value = Cow::Owned(after_spaces.into_owned());
+          modified = true;
+        }
+      }
+
+      // If the string was modified (and is now Cow::Owned),
+      // allocate it in the arena and update the attribute value.
+      if modified {
+        if let Cow::Owned(owned_str) = current_value {
+          // Allocate the modified string in the bump arena
+          *attr_value_ref = BumpString::from_str_in(&owned_str, self.arena).into_bump_str();
+        }
+        // If it's still Cow::Borrowed, it means either no modifications were made,
+        // or the modifications resulted in the original string, so no need to reassign.
+      }
+    }
+
+    VisitAction::Keep // Keep the element, we only modified its attributes
+  }
+}

--- a/src/plugins/convert_colors.rs
+++ b/src/plugins/convert_colors.rs
@@ -339,7 +339,7 @@ impl<'a> Plugin<'a> for ConvertColorsPlugin<'a> {
         continue;
       }
 
-      let original_value: &'a str = *attr_value_ref;
+      let original_value: &'a str = attr_value_ref;
       let mut current_val_cow: Cow<'a, str> = Cow::Borrowed(original_value);
       let mut modified = false;
 
@@ -500,11 +500,9 @@ impl<'a> Plugin<'a> for ConvertColorsPlugin<'a> {
   }
 
   fn element_exit(&mut self, el: &mut XMLAstElement<'a>) {
-    if el.name == "mask" {
-      if self.mask_counter > 0 {
-        // Should always be true if enter was paired
-        self.mask_counter -= 1;
-      }
+    if el.name == "mask" && self.mask_counter > 0 {
+      // Should always be true if enter was paired
+      self.mask_counter -= 1;
     }
   }
 }

--- a/src/plugins/convert_colors.rs
+++ b/src/plugins/convert_colors.rs
@@ -1,0 +1,508 @@
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+
+use bumpalo::collections::String as BumpString;
+use bumpalo::Bump;
+use derive_builder::Builder;
+use lazy_static::lazy_static;
+use regex::Regex;
+
+use crate::optimizer::{Plugin, VisitAction}; // Assuming these paths
+use crate::parser::XMLAstElement; // Assuming this path
+
+// --- Static Collections ---
+lazy_static! {
+    static ref COLORS_NAMES: HashMap<&'static str, &'static str> = {
+        let mut m = HashMap::new();
+        m.insert("aliceblue", "#f0f8ff");
+        m.insert("antiquewhite", "#faebd7");
+        m.insert("aqua", "#0ff"); // or #00ffff
+        m.insert("aquamarine", "#7fffd4");
+        m.insert("azure", "#f0ffff");
+        m.insert("beige", "#f5f5dc");
+        m.insert("bisque", "#ffe4c4");
+        m.insert("black", "#000"); // or #000000
+        m.insert("blanchedalmond", "#ffebcd");
+        m.insert("blue", "#00f"); // or #0000ff
+        m.insert("blueviolet", "#8a2be2");
+        m.insert("brown", "#a52a2a");
+        m.insert("burlywood", "#deb887");
+        m.insert("cadetblue", "#5f9ea0");
+        m.insert("chartreuse", "#7fff00");
+        m.insert("chocolate", "#d2691e");
+        m.insert("coral", "#ff7f50");
+        m.insert("cornflowerblue", "#6495ed");
+        m.insert("cornsilk", "#fff8dc");
+        m.insert("crimson", "#dc143c");
+        m.insert("cyan", "#0ff"); // or #00ffff, same as aqua
+        m.insert("darkblue", "#00008b");
+        m.insert("darkcyan", "#008b8b");
+        m.insert("darkgoldenrod", "#b8860b");
+        m.insert("darkgray", "#a9a9a9");
+        m.insert("darkgreen", "#006400");
+        m.insert("darkgrey", "#a9a9a9"); // same as darkgray
+        m.insert("darkkhaki", "#bdb76b");
+        m.insert("darkmagenta", "#8b008b");
+        m.insert("darkolivegreen", "#556b2f");
+        m.insert("darkorange", "#ff8c00");
+        m.insert("darkorchid", "#9932cc");
+        m.insert("darkred", "#8b0000");
+        m.insert("darksalmon", "#e9967a");
+        m.insert("darkseagreen", "#8fbc8f");
+        m.insert("darkslateblue", "#483d8b");
+        m.insert("darkslategray", "#2f4f4f");
+        m.insert("darkslategrey", "#2f4f4f"); // same as darkslategray
+        m.insert("darkturquoise", "#00ced1");
+        m.insert("darkviolet", "#9400d3");
+        m.insert("deeppink", "#ff1493");
+        m.insert("deepskyblue", "#00bfff");
+        m.insert("dimgray", "#696969");
+        m.insert("dimgrey", "#696969"); // same as dimgray
+        m.insert("dodgerblue", "#1e90ff");
+        m.insert("firebrick", "#b22222");
+        m.insert("floralwhite", "#fffaf0");
+        m.insert("forestgreen", "#228b22");
+        m.insert("fuchsia", "#f0f"); // or #ff00ff, same as magenta
+        m.insert("gainsboro", "#dcdcdc");
+        m.insert("ghostwhite", "#f8f8ff");
+        m.insert("gold", "#ffd700");
+        m.insert("goldenrod", "#daa520");
+        m.insert("gray", "#808080");
+        m.insert("green", "#008000");
+        m.insert("greenyellow", "#adff2f");
+        m.insert("grey", "#808080"); // same as gray
+        m.insert("honeydew", "#f0fff0");
+        m.insert("hotpink", "#ff69b4");
+        m.insert("indianred", "#cd5c5c");
+        m.insert("indigo", "#4b0082");
+        m.insert("ivory", "#fffff0");
+        m.insert("khaki", "#f0e68c");
+        m.insert("lavender", "#e6e6fa");
+        m.insert("lavenderblush", "#fff0f5");
+        m.insert("lawngreen", "#7cfc00");
+        m.insert("lemonchiffon", "#fffacd");
+        m.insert("lightblue", "#add8e6");
+        m.insert("lightcoral", "#f08080");
+        m.insert("lightcyan", "#e0ffff");
+        m.insert("lightgoldenrodyellow", "#fafad2");
+        m.insert("lightgray", "#d3d3d3");
+        m.insert("lightgreen", "#90ee90");
+        m.insert("lightgrey", "#d3d3d3"); // same as lightgray
+        m.insert("lightpink", "#ffb6c1");
+        m.insert("lightsalmon", "#ffa07a");
+        m.insert("lightseagreen", "#20b2aa");
+        m.insert("lightskyblue", "#87cefa");
+        m.insert("lightslategray", "#778899"); // JS has #789, which is short. CSS spec has #778899
+        m.insert("lightslategrey", "#778899"); // JS has #789
+        m.insert("lightsteelblue", "#b0c4de");
+        m.insert("lightyellow", "#ffffe0");
+        m.insert("lime", "#0f0"); // or #00ff00
+        m.insert("limegreen", "#32cd32");
+        m.insert("linen", "#faf0e6");
+        m.insert("magenta", "#f0f"); // or #ff00ff, same as fuchsia
+        m.insert("maroon", "#800000");
+        m.insert("mediumaquamarine", "#66cdaa");
+        m.insert("mediumblue", "#0000cd");
+        m.insert("mediumorchid", "#ba55d3");
+        m.insert("mediumpurple", "#9370db");
+        m.insert("mediumseagreen", "#3cb371");
+        m.insert("mediumslateblue", "#7b68ee");
+        m.insert("mediumspringgreen", "#00fa9a");
+        m.insert("mediumturquoise", "#48d1cc");
+        m.insert("mediumvioletred", "#c71585");
+        m.insert("midnightblue", "#191970");
+        m.insert("mintcream", "#f5fffa");
+        m.insert("mistyrose", "#ffe4e1");
+        m.insert("moccasin", "#ffe4b5");
+        m.insert("navajowhite", "#ffdead");
+        m.insert("navy", "#000080");
+        m.insert("oldlace", "#fdf5e6");
+        m.insert("olive", "#808000");
+        m.insert("olivedrab", "#6b8e23");
+        m.insert("orange", "#ffa500");
+        m.insert("orangered", "#ff4500");
+        m.insert("orchid", "#da70d6");
+        m.insert("palegoldenrod", "#eee8aa");
+        m.insert("palegreen", "#98fb98");
+        m.insert("paleturquoise", "#afeeee");
+        m.insert("palevioletred", "#db7093");
+        m.insert("papayawhip", "#ffefd5");
+        m.insert("peachpuff", "#ffdab9");
+        m.insert("peru", "#cd853f");
+        m.insert("pink", "#ffc0cb");
+        m.insert("plum", "#dda0dd");
+        m.insert("powderblue", "#b0e0e6");
+        m.insert("purple", "#800080");
+        m.insert("rebeccapurple", "#663399"); // JS has #639
+        m.insert("red", "#f00"); // or #ff0000
+        m.insert("rosybrown", "#bc8f8f");
+        m.insert("royalblue", "#4169e1");
+        m.insert("saddlebrown", "#8b4513");
+        m.insert("salmon", "#fa8072");
+        m.insert("sandybrown", "#f4a460");
+        m.insert("seagreen", "#2e8b57");
+        m.insert("seashell", "#fff5ee");
+        m.insert("sienna", "#a0522d");
+        m.insert("silver", "#c0c0c0");
+        m.insert("skyblue", "#87ceeb");
+        m.insert("slateblue", "#6a5acd");
+        m.insert("slategray", "#708090");
+        m.insert("slategrey", "#708090"); // same as slategray
+        m.insert("snow", "#fffafa");
+        m.insert("springgreen", "#00ff7f");
+        m.insert("steelblue", "#4682b4");
+        m.insert("tan", "#d2b48c");
+        m.insert("teal", "#008080");
+        m.insert("thistle", "#d8bfd8");
+        m.insert("tomato", "#ff6347");
+        m.insert("turquoise", "#40e0d0");
+        m.insert("violet", "#ee82ee");
+        m.insert("wheat", "#f5deb3");
+        m.insert("white", "#fff"); // or #ffffff
+        m.insert("whitesmoke", "#f5f5f5");
+        m.insert("yellow", "#ff0"); // or #ffff00
+        m.insert("yellowgreen", "#9acd32");
+        m
+    };
+
+    static ref COLORS_SHORT_NAMES: HashMap<&'static str, &'static str> = {
+        let mut m = HashMap::new();
+        m.insert("#f0ffff", "azure");
+        m.insert("#f5f5dc", "beige");
+        m.insert("#ffe4c4", "bisque");
+        m.insert("#a52a2a", "brown");
+        m.insert("#ff7f50", "coral");
+        m.insert("#ffd700", "gold");
+        m.insert("#808080", "gray"); // and grey
+        m.insert("#008000", "green");
+        m.insert("#4b0082", "indigo");
+        m.insert("#fffff0", "ivory");
+        m.insert("#f0e68c", "khaki");
+        m.insert("#faf0e6", "linen");
+        m.insert("#800000", "maroon");
+        m.insert("#000080", "navy");
+        m.insert("#808000", "olive");
+        m.insert("#ffa500", "orange");
+        m.insert("#da70d6", "orchid");
+        m.insert("#cd853f", "peru");
+        m.insert("#ffc0cb", "pink");
+        m.insert("#dda0dd", "plum");
+        m.insert("#800080", "purple");
+        m.insert("#f00", "red"); // Short hex for red
+        m.insert("#ff0000", "red"); // Long hex for red
+        m.insert("#fa8072", "salmon");
+        m.insert("#a0522d", "sienna");
+        m.insert("#c0c0c0", "silver");
+        m.insert("#fffafa", "snow");
+        m.insert("#d2b48c", "tan");
+        m.insert("#008080", "teal");
+        m.insert("#ff6347", "tomato");
+        m.insert("#ee82ee", "violet");
+        m.insert("#f5deb3", "wheat");
+        // Add other short hex names if necessary, e.g. #000 for black, #fff for white
+        m.insert("#000", "black");
+        m.insert("#000000", "black");
+        m.insert("#fff", "white");
+        m.insert("#ffffff", "white");
+        m.insert("#0ff", "aqua"); // or cyan
+        m.insert("#00ffff", "aqua");
+        m.insert("#f0f", "fuchsia"); // or magenta
+        m.insert("#ff00ff", "fuchsia");
+        m
+    };
+
+    static ref COLORS_PROPS: HashSet<&'static str> = {
+        let mut s = HashSet::new();
+        s.insert("color");
+        s.insert("fill");
+        s.insert("flood-color");
+        s.insert("lighting-color");
+        s.insert("stop-color");
+        s.insert("stroke");
+        s
+    };
+
+    // Regexes
+    // rNumber = '([+-]?(?:\d*\.\d+|\d+\.?)%?)'
+    // rComma = '(?:\s*,\s*|\s+)'
+    // regRGB = new RegExp('^rgb\\(\\s*' + rNumber + rComma + rNumber + rComma + rNumber + '\\s*\\)$')
+    static ref REG_RGB: Regex = Regex::new(&format!(
+        r"^rgb\(\s*({0}){1}({0}){1}({0})\s*\)$",
+        r"[+-]?(?:(?:\d*\.\d+|\d+\.?))%?", // Simplified rNumber for capture
+        r"(?:\s*,\s*|\s+)" // rComma
+    )).unwrap();
+
+    // regHEX = /^#(([a-fA-F0-9])\2){3}$/;
+    // This regex checks if a long hex can be shortened, e.g., #AABBCC
+    // It captures the *last* pair and its constituent character in JS.
+    // For Rust, to get the components for shortening, a different regex is more direct:
+    static ref REG_HEX_SHORTENABLE: Regex = Regex::new(r"^#([0-9a-fA-F])\1([0-9a-fA-F])\2([0-9a-fA-F])\3$").unwrap();
+
+    // For includesUrlReference, based on `url(#...)`
+    static ref REG_URL_REFERENCE: Regex = Regex::new(r"url\(#.+?\)").unwrap();
+}
+
+// --- Configuration Enums ---
+#[derive(Debug, Clone, PartialEq)]
+pub enum CaseConvention {
+  Lower,
+  Upper,
+}
+
+#[derive(Debug, Clone)]
+pub enum CurrentColorType {
+  Enabled,          // JS `true`
+  Specific(String), // JS `string` to match
+  Pattern(String),  // JS `RegExp` string to match
+}
+
+// --- Configuration Struct ---
+#[derive(Debug, Builder, Clone)]
+#[builder(setter(into, strip_option), default)] // `default` calls ConvertColorsPluginConfig::default()
+pub struct ConvertColorsPluginConfig {
+  pub current_color: Option<CurrentColorType>,
+  pub names_to_hex: bool,
+  pub rgb_to_hex: bool,
+  pub convert_case: Option<CaseConvention>,
+  pub short_hex: bool,
+  pub short_name: bool,
+}
+
+impl Default for ConvertColorsPluginConfig {
+  fn default() -> Self {
+    ConvertColorsPluginConfig {
+      current_color: None, // JS default `false`
+      names_to_hex: true,
+      rgb_to_hex: true,
+      convert_case: Some(CaseConvention::Lower), // JS default `'lower'`
+      short_hex: true,
+      short_name: true,
+    }
+  }
+}
+
+// --- Plugin Struct ---
+pub struct ConvertColorsPlugin<'a> {
+  arena: &'a Bump,
+  config: ConvertColorsPluginConfig,
+  mask_counter: u32,
+  // Compiled regex for current_color if it's a pattern
+  current_color_pattern_regex: Option<Regex>,
+}
+
+impl<'a> ConvertColorsPlugin<'a> {
+  pub fn new(config: ConvertColorsPluginConfig, arena: &'a Bump) -> Self {
+    let current_color_pattern_regex = match &config.current_color {
+      Some(CurrentColorType::Pattern(s)) => Regex::new(s).ok(),
+      _ => None,
+    };
+    Self {
+      arena,
+      config,
+      mask_counter: 0,
+      current_color_pattern_regex,
+    }
+  }
+
+  // Helper: Convert [r, g, b] (u8) to #rrggbb string
+  fn rgb_to_hex_string(&self, r: u8, g: u8, b: u8) -> String {
+    format!("#{:02x}{:02x}{:02x}", r, g, b) // Default to lowercase as per CSS and many tools
+  }
+
+  // Helper: checks if a string contains a url reference like url(#...)
+  fn includes_url_reference(&self, s: &str) -> bool {
+    REG_URL_REFERENCE.is_match(s)
+  }
+}
+
+// --- Plugin Implementation ---
+impl<'a> Plugin<'a> for ConvertColorsPlugin<'a> {
+  fn element_enter(&mut self, el: &mut XMLAstElement<'a>) -> VisitAction {
+    if el.name == "mask" {
+      self.mask_counter += 1;
+    }
+
+    for (_attr_name, attr_value_ref) in el.attributes.iter_mut() {
+      // Only process attributes that are known to accept color values
+      // The JS version iterates all attributes and checks `colorsProps.has(name)`.
+      // Assuming _attr_name is &'a str, we need to ensure it's comparable to keys in COLORS_PROPS.
+      // For now, let's assume _attr_name is already suitable or convert it.
+      // In the provided example, _attr_name is not used directly to filter,
+      // but here we need to check against COLORS_PROPS.
+      // Let's assume for now that this check happens *before* calling this plugin,
+      // or that we should add it here if `el.attributes` is generic.
+      // The JS plugin does `if (colorsProps.has(name))`. So we should too.
+      let attr_name_str: &str = _attr_name; // Assuming _attr_name is &'a str
+      if !COLORS_PROPS.contains(attr_name_str) {
+        continue;
+      }
+
+      let original_value: &'a str = *attr_value_ref;
+      let mut current_val_cow: Cow<'a, str> = Cow::Borrowed(original_value);
+      let mut modified = false;
+
+      // 1. Convert to currentColor
+      if self.mask_counter == 0 {
+        if let Some(cc_type) = &self.config.current_color {
+          let matched = match cc_type {
+            CurrentColorType::Enabled => current_val_cow != "none",
+            CurrentColorType::Specific(s_match) => current_val_cow == *s_match,
+            CurrentColorType::Pattern(_) => {
+              if let Some(ref regex) = self.current_color_pattern_regex {
+                regex.is_match(&current_val_cow)
+              } else {
+                false // Pattern provided but regex compilation failed
+              }
+            }
+          };
+          if matched {
+            current_val_cow = Cow::Borrowed("currentcolor");
+            modified = true;
+          }
+        }
+      }
+
+      // If value is "currentcolor" or "none", further color conversions are usually skipped.
+      // The JS plugin continues processing, which might be fine.
+      // Let's see: if val is "currentcolor", names2hex/rgb2hex won't match.
+      // convertCase could change "currentcolor" to "CURRENTCOLOR".
+      // shorthex/shortname won't match. So it's probably fine.
+
+      if current_val_cow == "currentcolor" || current_val_cow == "none" {
+        // Update attribute if it was changed to currentcolor and skip further processing for it.
+        if modified {
+          *attr_value_ref =
+            BumpString::from_str_in(current_val_cow.as_ref(), self.arena).into_bump_str();
+        }
+        continue; // Skip other conversions for "currentcolor" or "none"
+      }
+
+      // 2. Convert color name keyword to long hex
+      if self.config.names_to_hex {
+        // Lookup requires lowercase
+        let potential_name_key = current_val_cow.to_lowercase();
+        if let Some(hex_color) = COLORS_NAMES.get(potential_name_key.as_str()) {
+          if current_val_cow != *hex_color {
+            current_val_cow = Cow::Borrowed(hex_color); // Values from COLORS_NAMES are &'static str
+            modified = true;
+          }
+        }
+      }
+
+      // 3. Convert rgb() to long hex
+      if self.config.rgb_to_hex {
+        if let Some(caps) = REG_RGB.captures(&current_val_cow) {
+          let mut nums: [u8; 3] = [0; 3];
+          let mut conversion_ok = true;
+          for i in 0..3 {
+            let m = caps.get(i + 1).unwrap().as_str(); // Captures are 1-indexed
+            let val_str: Cow<str>;
+            let is_percent = if m.ends_with('%') {
+              val_str = Cow::Borrowed(&m[..m.len() - 1]);
+              true
+            } else {
+              val_str = Cow::Borrowed(m);
+              false
+            };
+
+            if let Ok(n_float) = val_str.parse::<f64>() {
+              let n = if is_percent {
+                (n_float * 2.55).round()
+              } else {
+                n_float.round()
+              };
+              // Clamp and convert to u8
+              nums[i] = n.max(0.0).min(255.0) as u8;
+            } else {
+              conversion_ok = false; // Parsing failed
+              break;
+            }
+          }
+          if conversion_ok {
+            let hex_color_str = self.rgb_to_hex_string(nums[0], nums[1], nums[2]);
+            if current_val_cow != hex_color_str {
+              current_val_cow = Cow::Owned(hex_color_str);
+              modified = true;
+            }
+          }
+        }
+      }
+
+      // 4. Convert case (upper/lower) for hex colors
+      // The JS applies this more broadly; here we'll be more careful if it's a hex.
+      // JS: `if (convertCase && !includesUrlReference(val))`
+      if let Some(ref convention) = self.config.convert_case {
+        if !self.includes_url_reference(&current_val_cow) {
+          // Only apply to hex colors for safety, though JS is broader
+          if current_val_cow.starts_with('#') {
+            let original_case_val = current_val_cow.to_string(); // temp store
+            let new_case_val = match convention {
+              CaseConvention::Lower => current_val_cow.to_lowercase(),
+              CaseConvention::Upper => current_val_cow.to_uppercase(),
+            };
+            if original_case_val != new_case_val {
+              current_val_cow = Cow::Owned(new_case_val);
+              modified = true;
+            }
+          }
+        }
+      }
+
+      // 5. Convert long hex to short hex (e.g., #aabbcc -> #abc)
+      // This should happen *after* case conversion if we want #ABC from #AABBCC with uppercase.
+      // However, the output of shortener is usually lowercase: #abc
+      if self.config.short_hex && current_val_cow.starts_with('#') && current_val_cow.len() == 7 {
+        if let Some(caps) = REG_HEX_SHORTENABLE.captures(&current_val_cow) {
+          // caps[1], caps[2], caps[3] are the chars for the short hex
+          let r = caps.get(1).unwrap().as_str();
+          let g = caps.get(2).unwrap().as_str();
+          let b = caps.get(3).unwrap().as_str();
+
+          // Preserve case from the original string if convert_case was 'upper'
+          // Or, standardize to lower, which is more common for shorthex.
+          // JS: '#' + match[0][1] + match[0][3] + match[0][5]; implies direct char copy.
+          let short_hex_val = format!("#{}{}{}", r, g, b);
+
+          if current_val_cow != short_hex_val {
+            current_val_cow = Cow::Owned(short_hex_val);
+            modified = true;
+          }
+        }
+      }
+
+      // 6. Convert hex to short name (e.g., #f00 -> red)
+      if self.config.short_name && current_val_cow.starts_with('#') {
+        let lower_hex_key = current_val_cow.to_lowercase(); // Lookup always with lowercase
+        if let Some(short_name) = COLORS_SHORT_NAMES.get(lower_hex_key.as_str()) {
+          if current_val_cow != *short_name {
+            // Check if it's different before assigning
+            current_val_cow = Cow::Borrowed(short_name); // short_name is &'static str
+            modified = true;
+          }
+        }
+      }
+
+      if modified {
+        if let Cow::Owned(owned_str) = current_val_cow {
+          *attr_value_ref = BumpString::from_str_in(&owned_str, self.arena).into_bump_str();
+        } else if let Cow::Borrowed(borrowed_str) = current_val_cow {
+          // If it's borrowed but different from original_value, it means it came from a static source
+          if borrowed_str != original_value {
+            *attr_value_ref = BumpString::from_str_in(borrowed_str, self.arena).into_bump_str();
+          }
+          // If borrowed_str == original_value, no actual change happened, so no need to reassign.
+        }
+      }
+    }
+    VisitAction::Keep
+  }
+
+  fn element_exit(&mut self, el: &mut XMLAstElement<'a>) {
+    if el.name == "mask" {
+      if self.mask_counter > 0 {
+        // Should always be true if enter was paired
+        self.mask_counter -= 1;
+      }
+    }
+  }
+}

--- a/src/plugins/convert_colors.rs
+++ b/src/plugins/convert_colors.rs
@@ -244,12 +244,14 @@ lazy_static! {
 
 // --- Configuration Enums ---
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum CaseConvention {
   Lower,
   Upper,
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum CurrentColorType {
   Enabled,          // JS `true`
   Specific(String), // JS `string` to match

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,3 +1,4 @@
+pub mod cleanup_attrs;
 pub mod move_elems_attrs_to_group;
 pub mod remove_comments;
 pub mod remove_desc;

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,4 +1,5 @@
 pub mod cleanup_attrs;
+pub mod convert_colors;
 pub mod move_elems_attrs_to_group;
 pub mod remove_comments;
 pub mod remove_desc;

--- a/src/plugins/move_elems_attrs_to_group.rs
+++ b/src/plugins/move_elems_attrs_to_group.rs
@@ -135,7 +135,7 @@ impl<'a> Plugin<'a> for MoveElemsAttrsToGroupPlugin<'a> {
     }
   }
 
-  fn element_exit(&self, el: &mut XMLAstElement<'a>) {
+  fn element_exit(&mut self, el: &mut XMLAstElement<'a>) {
     // Process only groups with more than 1 child
     if el.name != "g" || el.children.len() <= 1 {
       return;

--- a/src/plugins/move_elems_attrs_to_group.rs
+++ b/src/plugins/move_elems_attrs_to_group.rs
@@ -35,7 +35,7 @@ impl<'a> MoveElemsAttrsToGroupPlugin<'a> {
   pub fn new(_config: MoveElemsAttrsToGroupPluginConfig, arena: &'a Bump) -> Self {
     MoveElemsAttrsToGroupPlugin {
       has_style_element: false,
-      arena: arena,
+      arena,
     }
   }
 }

--- a/src/plugins/remove_comments.rs
+++ b/src/plugins/remove_comments.rs
@@ -17,7 +17,7 @@ pub struct RemoveCommentsConfig {
 impl<'a> RemoveCommentsPlugin<'a> {
   pub fn new(config: RemoveCommentsConfig, arena: &'a Bump) -> Self {
     RemoveCommentsPlugin {
-      arena: arena,
+      arena,
       preserve_patterns: config
         .preserve_patterns
         .unwrap_or_else(|| vec![Regex::new(r"^!").unwrap()]),
@@ -31,7 +31,7 @@ impl<'a> Plugin<'a> for RemoveCommentsPlugin<'a> {
     for pattern in &self.preserve_patterns {
       // Check if the comment text matches the current pattern
       // Assuming el.value contains the comment text
-      if pattern.is_match(&_el.value) {
+      if pattern.is_match(_el.value) {
         // If it matches, keep the comment and stop checking
         return VisitAction::Keep;
       }

--- a/src/plugins/remove_desc.rs
+++ b/src/plugins/remove_desc.rs
@@ -20,7 +20,7 @@ pub struct RemoveDescPluginConfig {
 impl<'a> RemoveDescPlugin<'a> {
   pub fn new(config: RemoveDescPluginConfig, arena: &'a Bump) -> Self {
     RemoveDescPlugin {
-      arena: arena,
+      arena,
       remove_any: config.remove_any,
     }
   }
@@ -32,9 +32,9 @@ impl<'a> Plugin<'a> for RemoveDescPlugin<'a> {
       if self.remove_any {
         return VisitAction::Remove;
       }
-      match el.children.get(0) {
+      match el.children.first() {
         None => VisitAction::Remove,
-        Some(XMLAstChild::Text(t)) if is_standard_desc(&t.value) => VisitAction::Remove,
+        Some(XMLAstChild::Text(t)) if is_standard_desc(t.value) => VisitAction::Remove,
         _ => VisitAction::Keep,
       }
     } else {

--- a/src/plugins/remove_doctype.rs
+++ b/src/plugins/remove_doctype.rs
@@ -13,7 +13,7 @@ pub struct RemoveDoctypePluginConfig {}
 
 impl<'a> RemoveDoctypePlugin<'a> {
   pub fn new(_config: RemoveDoctypePluginConfig, arena: &'a Bump) -> Self {
-    RemoveDoctypePlugin { arena: arena }
+    RemoveDoctypePlugin { arena }
   }
 }
 

--- a/src/plugins/remove_metadata.rs
+++ b/src/plugins/remove_metadata.rs
@@ -12,7 +12,7 @@ pub struct RemoveMetadataPluginConfig {}
 
 impl<'a> RemoveMetadataPlugin<'a> {
   pub fn new(_config: RemoveMetadataPluginConfig, arena: &'a Bump) -> Self {
-    RemoveMetadataPlugin { arena: arena }
+    RemoveMetadataPlugin { arena }
   }
 }
 

--- a/src/plugins/remove_title.rs
+++ b/src/plugins/remove_title.rs
@@ -12,7 +12,7 @@ pub struct RemoveTitlePluginConfig {}
 
 impl<'a> RemoveTitlePlugin<'a> {
   pub fn new(_config: RemoveTitlePluginConfig, arena: &'a Bump) -> Self {
-    RemoveTitlePlugin { arena: arena }
+    RemoveTitlePlugin { arena }
   }
 }
 

--- a/src/plugins/remove_xml_proc_inst.rs
+++ b/src/plugins/remove_xml_proc_inst.rs
@@ -12,7 +12,7 @@ pub struct RemoveXMLProcInstPluginConfig {}
 
 impl<'a> RemoveXMLProcInstPlugin<'a> {
   pub fn new(_config: RemoveXMLProcInstPluginConfig, arena: &'a Bump) -> Self {
-    RemoveXMLProcInstPlugin { arena: arena }
+    RemoveXMLProcInstPlugin { arena }
   }
 }
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the SVG optimization library by adding new plugins, improving existing plugin functionality, and updating dependencies. The most important changes include the addition of the `CleanupAttrs` plugin, updates to the plugin system to allow mutable access during `element_exit`, and modifications to the test cases to reflect these updates.

### New Plugins and Features:
* Added the `CleanupAttrs` plugin, which processes SVG attributes to clean up newlines, trim whitespace, and collapse multiple spaces. This includes the implementation of the `CleanupAttrsConfig` for customizable behavior. (`src/plugins/cleanup_attrs.rs`, `src/plugins/mod.rs`, `src/lib.rs`) [[1]](diffhunk://#diff-d50388cecb484a128786833e2278ec6538a68ac65cb763d0af49ea7ca7d7e1feR1-R113) [[2]](diffhunk://#diff-81622de67d9d2c5e34d9e7e7e05d0f6185a408d81cefdc2c8f3a6a72a33cc9f8R1-R2) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R9-R10) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R64-R71)

### Plugin System Enhancements:
* Updated the `Plugin` trait to allow mutable access in the `element_exit` method, enabling plugins to modify elements during the exit phase. (`src/optimizer.rs`)
* Adjusted the `SvgOptimizer` implementation to iterate over plugins mutably when calling `element_exit`. (`src/optimizer.rs`)

### Dependency Updates:
* Added new dependencies: `derive_builder` for configuration building and `fancy-regex` for advanced regex processing. (`Cargo.toml`)

### Test Updates:
* Updated the `index.spec.ts` test case to use a new SVG input format, reflecting the changes introduced by the new plugins and optimizations. (`__test__/index.spec.ts`)

### Minor Fixes:
* Modified the `MoveElemsAttrsToGroupPlugin` to allow mutable access in its `element_exit` method for consistency with other plugins. (`src/plugins/move_elems_attrs_to_group.rs`)